### PR TITLE
デザイン修正＆ありがとう一覧をクエリパラメーターに修正

### DIFF
--- a/entity/User.ts
+++ b/entity/User.ts
@@ -1,4 +1,4 @@
 export type User = {
-  name: number
+  name: string
   email: string
 }

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -18,6 +18,6 @@ export default async function({ store, route, redirect }) {
     redirect('/signin')
   }
   if (isAuthenticated && isSignin) {
-    redirect('/')
+    redirect(route.fullPath)
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-content class="thanks_main">
     <loading v-if="isLoading" />
-    <v-card v-else>
+    <v-card v-else width="1000px" class="mx-auto">
       <v-img class="white--text align-end" height="550px" src="/thanks.jpg" />
 
       <v-card-title>ありがとう受付窓口</v-card-title>

--- a/pages/thanks.vue
+++ b/pages/thanks.vue
@@ -1,6 +1,6 @@
 <template>
   <v-content class="thanks_main">
-    <h1 class="page_title">ありがとう一覧</h1>
+    <h1 class="page_title">{{ userName }}さんのありがとう一覧</h1>
     <v-data-table :headers="headers" :items="messages" :items-per-page="20" />
     <v-btn class="ma-2" color="primary" to="/users"> <v-icon left>mdi-arrow-left</v-icon>Back </v-btn>
   </v-content>
@@ -20,7 +20,9 @@ import { Message } from '@/entity/Message'
 export default class Thanks extends Vue {
   messages: Message[] = []
 
-  headers: any[] = [
+  userName: string = ''
+
+  readonly headers: any[] = [
     { text: '誰から', value: 'from', sortable: true, width: '10%' },
     { text: '日付', value: 'createdAt', sortable: true, width: '10%' },
     { text: 'N-Devスピリット', value: 'nDevSpirits', sortable: true, width: '20%' },
@@ -28,7 +30,8 @@ export default class Thanks extends Vue {
   ]
 
   async created() {
-    const users = await store.findMessagesByEmail(this.$route.params.email)
+    this.userName = String(this.$route.query.name)
+    const users = await store.findMessagesByEmail(String(this.$route.query.email))
     users.forEach((doc) => {
       this.messages.push({
         from: doc.data().from,

--- a/pages/users.vue
+++ b/pages/users.vue
@@ -2,7 +2,7 @@
   <v-content class="thanks_main">
     <h1 class="page_title">メンバー一覧</h1>
     <v-list two-line subheader>
-      <v-list-item v-for="user in users" :key="user.email" @click="showThanks(user.email)">
+      <v-list-item v-for="user in users" :key="user.email" @click="showThanks(user.name, user.email)">
         <v-list-item-avatar>
           <!-- TODO: 認証情報から取ってきたアイコンを表示させる -->
           <v-icon class="grey lighten-1 white--text">mdi-account</v-icon>
@@ -18,6 +18,7 @@
 </template>
 
 <script lang="ts">
+import { Location } from 'vue-router'
 import { Vue, Component } from 'vue-property-decorator'
 import { store } from '@/plugins/firebase/fireStore'
 import { User } from '@/entity/User'
@@ -36,8 +37,12 @@ export default class Users extends Vue {
     store.findMaster('users').then((res) => (this.users = res.data()!.items))
   }
 
-  showThanks(email: string) {
-    this.$router.push({ path: `/thanks/${email}` })
+  showThanks(queryName: string, queryEmail: string) {
+    const location: Location = {
+      name: 'thanks',
+      query: { name: queryName, email: queryEmail }
+    }
+    this.$router.push(location)
   }
 }
 </script>


### PR DESCRIPTION
## やったこと
- ありがとう投稿画面の横幅指定＆中央固定にした
- ありがとう一覧画面に名前を表示した
- ありがとう一覧画面をパスパラメータ→クエリパラメータにした（本番環境でリロードしても404にならないようにするため）
- ログイン中にリロードしたら、現在のパスにリダイレクトするようした